### PR TITLE
Add unvalidated marshalling and signing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53
 	github.com/veraison/go-cose v1.0.0-rc.1
-	github.com/veraison/psatoken v1.0.0-rc2.0.20230124001050-d5d26fdd5322
+	github.com/veraison/psatoken v1.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53 h1:5gnX2TrGd/Xz8DOp2O
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
 github.com/veraison/go-cose v1.0.0-rc.1 h1:4qA7dbFJGvt7gcqv5MCIyCQvN+NpHFPkW7do3EeDLb8=
 github.com/veraison/go-cose v1.0.0-rc.1/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
-github.com/veraison/psatoken v1.0.0-rc2.0.20230124001050-d5d26fdd5322 h1:ad6FTMFIjQeG4ObFeoUjstiDdXYn5opEnq8C0jmGlog=
-github.com/veraison/psatoken v1.0.0-rc2.0.20230124001050-d5d26fdd5322/go.mod h1:2tHLoYMOIS4V4mO8MJT4VstRtpO50FLmhoOR35FyIr4=
+github.com/veraison/psatoken v1.2.0 h1:PeHy6YUbhFE9Z9xaQBoAMpMWUEqSHrF2JgfcwMTmFIA=
+github.com/veraison/psatoken v1.2.0/go.mod h1:2tHLoYMOIS4V4mO8MJT4VstRtpO50FLmhoOR35FyIr4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/iclaims.go
+++ b/iclaims.go
@@ -30,10 +30,14 @@ type IClaims interface {
 	// CBOR codecs
 	FromCBOR([]byte) error
 	ToCBOR() ([]byte, error)
+	FromUnvalidatedCBOR([]byte) error
+	ToUnvalidatedCBOR() ([]byte, error)
 
 	// JSON codecs
 	FromJSON([]byte) error
 	ToJSON() ([]byte, error)
+	FromUnvalidatedJSON([]byte) error
+	ToUnvalidatedJSON() ([]byte, error)
 
 	// Semantic validation
 	Validate() error
@@ -47,16 +51,6 @@ func DecodeClaims(buf []byte) (IClaims, error) {
 	cl := &RealmClaims{}
 
 	if err := cl.FromCBOR(buf); err != nil {
-		return nil, err
-	}
-
-	return cl, nil
-}
-
-func DecodeJSONClaims(buf []byte) (IClaims, error) {
-	cl := &RealmClaims{}
-
-	if err := cl.FromJSON(buf); err != nil {
 		return nil, err
 	}
 

--- a/realm_claims.go
+++ b/realm_claims.go
@@ -186,14 +186,23 @@ func (c RealmClaims) Validate() error {
 // Codecs
 
 func (c *RealmClaims) FromCBOR(buf []byte) error {
-	err := dm.Unmarshal(buf, c)
+	err := c.FromUnvalidatedCBOR(buf)
 	if err != nil {
-		return fmt.Errorf("CBOR decoding of CCA realm claims failed: %w", err)
+		return err
 	}
 
 	err = c.Validate()
 	if err != nil {
 		return fmt.Errorf("validation of CCA realm claims failed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *RealmClaims) FromUnvalidatedCBOR(buf []byte) error {
+	err := dm.Unmarshal(buf, c)
+	if err != nil {
+		return fmt.Errorf("CBOR decoding of CCA realm claims failed: %w", err)
 	}
 
 	return nil
@@ -205,6 +214,10 @@ func (c RealmClaims) ToCBOR() ([]byte, error) {
 		return nil, fmt.Errorf("validation of CCA realm claims failed: %w", err)
 	}
 
+	return c.ToUnvalidatedCBOR()
+}
+
+func (c RealmClaims) ToUnvalidatedCBOR() ([]byte, error) {
 	buf, err := em.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("CBOR encoding of CCA realm claims failed: %w", err)
@@ -214,14 +227,23 @@ func (c RealmClaims) ToCBOR() ([]byte, error) {
 }
 
 func (c *RealmClaims) FromJSON(buf []byte) error {
-	err := json.Unmarshal(buf, c)
+	err := c.FromUnvalidatedJSON(buf)
 	if err != nil {
-		return fmt.Errorf("JSON decoding of CCA realm claims failed: %w", err)
+		return err
 	}
 
 	err = c.Validate()
 	if err != nil {
 		return fmt.Errorf("validation of CCA realm claims failed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *RealmClaims) FromUnvalidatedJSON(buf []byte) error {
+	err := json.Unmarshal(buf, c)
+	if err != nil {
+		return fmt.Errorf("JSON decoding of CCA realm claims failed: %w", err)
 	}
 
 	return nil
@@ -233,6 +255,10 @@ func (c RealmClaims) ToJSON() ([]byte, error) {
 		return nil, fmt.Errorf("validation of CCA realm claims failed: %w", err)
 	}
 
+	return c.ToUnvalidatedJSON()
+}
+
+func (c RealmClaims) ToUnvalidatedJSON() ([]byte, error) {
 	buf, err := json.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("JSON encoding of CCA realm claims failed: %w", err)


### PR DESCRIPTION
Add methods to allow unvalidated marshalling, unmarshalling and signing of CCA evidence. This is intended to support testing.

NOTE: this depends on https://github.com/veraison/psatoken/pull/46