### PR TITLE
Marshaling refactor

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -14,7 +14,7 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover ≥85.0%
+name: cover ≥83.1%
 on: [push, pull_request]
 jobs:
   cover:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53
 	github.com/veraison/go-cose v1.1.0
-	github.com/veraison/psatoken v1.2.1-0.20240718103721-89fde617284b
+	github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53 h1:5gnX2TrGd/Xz8DOp2O
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
 github.com/veraison/go-cose v1.1.0 h1:AalPS4VGiKavpAzIlBjrn7bhqXiXi4jbMYY/2+UC+4o=
 github.com/veraison/go-cose v1.1.0/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
-github.com/veraison/psatoken v1.2.1-0.20240718103721-89fde617284b h1:dFgjvrZWCalGq/Di9d8sIGXQPJ+CbmDbrl2eK6HbXJI=
-github.com/veraison/psatoken v1.2.1-0.20240718103721-89fde617284b/go.mod h1:6+WZzXr0ACXYiUAJJqTaCxW43gY2+gEaCoVNdDv3+Bw=
+github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4 h1:N7qg7vDF2mUg7I+8AoU+ieJ20cgcShwFHXHkV5b2YAA=
+github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4/go.mod h1:6+WZzXr0ACXYiUAJJqTaCxW43gY2+gEaCoVNdDv3+Bw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/platform/claims.go
+++ b/platform/claims.go
@@ -65,108 +65,39 @@ func (c *Claims) Validate() error {
 
 // Codecs
 
-func (c *Claims) FromCBOR(buf []byte) error {
-	err := c.FromUnvalidatedCBOR(buf)
-	if err != nil {
-		return err
-	}
+// this type alias is used to prevent infinite recursion during marshaling.
+type claims Claims
 
-	err = c.Validate()
-	if err != nil {
-		return fmt.Errorf("validation of CCA platform claims failed: %w", err)
-	}
-
-	return nil
-}
-
-func (c *Claims) FromUnvalidatedCBOR(buf []byte) error {
+// MarshalCBOR encodes the claims into CBOR
+func (c *Claims) UnmarshalCBOR(buf []byte) error {
 	c.Profile = nil // clear profile to make sure we taked it from buf
 
-	err := dm.Unmarshal(buf, c)
-	if err != nil {
-		return fmt.Errorf("CBOR decoding of CCA platform claims failed: %w", err)
-	}
-
-	return nil
+	return dm.Unmarshal(buf, (*claims)(c))
 }
 
-func (c *Claims) ToCBOR() ([]byte, error) {
-	err := c.Validate()
-	if err != nil {
-		return nil, fmt.Errorf("validation of CCA platform claims failed: %w", err)
-	}
-
-	return c.ToUnvalidatedCBOR()
-}
-
-func (c *Claims) ToUnvalidatedCBOR() ([]byte, error) {
-	var scs psatoken.ISwComponents
+// UnmarshalCBOR decodes the claims from CBOR
+func (c Claims) MarshalCBOR() ([]byte, error) {
 	if c.SwComponents != nil && c.SwComponents.IsEmpty() {
-		scs = c.SwComponents
 		c.SwComponents = nil
 	}
 
-	buf, err := em.Marshal(&c)
-	if scs != nil {
-		c.SwComponents = scs
-	}
-	if err != nil {
-		return nil, fmt.Errorf("CBOR encoding of CCA platform claims failed: %w", err)
-	}
-
-	return buf, nil
+	return em.Marshal((*claims)(&c))
 }
 
-func (c *Claims) FromJSON(buf []byte) error {
-	err := c.FromUnvalidatedJSON(buf)
-	if err != nil {
-		return err
-	}
-
-	err = c.Validate()
-	if err != nil {
-		return fmt.Errorf("validation of CCA platform claims failed: %w", err)
-	}
-
-	return nil
-}
-
-func (c *Claims) FromUnvalidatedJSON(buf []byte) error {
+// UnmarshalJSON decodes the claims from JSON
+func (c *Claims) UnmarshalJSON(buf []byte) error {
 	c.Profile = nil // clear profile to make sure we taked it from buf
 
-	err := json.Unmarshal(buf, c)
-	if err != nil {
-		return fmt.Errorf("JSON decoding of CCA platform claims failed: %w", err)
-	}
-
-	return nil
+	return json.Unmarshal(buf, (*claims)(c))
 }
 
-func (c *Claims) ToJSON() ([]byte, error) {
-	err := c.Validate()
-	if err != nil {
-		return nil, fmt.Errorf("validation of CCA platform claims failed: %w", err)
-	}
-
-	return c.ToUnvalidatedJSON()
-}
-
-func (c *Claims) ToUnvalidatedJSON() ([]byte, error) {
-	var scs psatoken.ISwComponents
+// MarshalJSON encodes the claims into JSON
+func (c Claims) MarsahlJSON() ([]byte, error) {
 	if c.SwComponents != nil && c.SwComponents.IsEmpty() {
-		scs = c.SwComponents
 		c.SwComponents = nil
 	}
 
-	buf, err := json.Marshal(&c)
-	if scs != nil {
-		c.SwComponents = scs
-	}
-	if err != nil {
-		return nil, fmt.Errorf("JSON encoding of CCA platform claims failed: %w", err)
-	}
-
-	return buf, nil
+	return json.Marshal((*claims)(&c))
 }
 
 func (c *Claims) SetImplID(v []byte) error {

--- a/platform/iclaims.go
+++ b/platform/iclaims.go
@@ -4,6 +4,7 @@
 package platform
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/veraison/psatoken"
@@ -18,17 +19,6 @@ type IClaims interface {
 
 	SetConfig([]byte) error
 	SetHashAlgID(string) error
-}
-
-// DecodeClaims unmarshals CCA platform claims from provided CBOR data.
-func DecodeClaims(buf []byte) (IClaims, error) {
-	cl := NewClaims()
-
-	if err := cl.FromCBOR(buf); err != nil {
-		return nil, err
-	}
-
-	return cl, nil
 }
 
 // ValidateClaims returns an error if the provided IClaims instance does not
@@ -47,4 +37,94 @@ func ValidateClaims(c IClaims) error {
 	}
 
 	return nil
+}
+
+// DecodeAndValidateClaimsFromCBOR unmarshals and validates CCA platform claims
+// from provided CBOR buf.
+func DecodeAndValidateClaimsFromCBOR(buf []byte) (IClaims, error) {
+	cl, err := DecodeClaimsFromCBOR(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cl.Validate(); err != nil {
+		return nil, err
+	}
+
+	return cl, nil
+}
+
+// DecodeClaimsFromCBOR unmarshals CCA platform claims from provided CBOR buf.
+func DecodeClaimsFromCBOR(buf []byte) (IClaims, error) {
+	cl := NewClaims()
+
+	if err := dm.Unmarshal(buf, cl); err != nil {
+		return nil, err
+	}
+
+	return cl, nil
+}
+
+// DecodeAndValidateClaimsFromJSON unmarshals and validates CCA platform claims
+// from provided JSON buf.
+func DecodeAndValidateClaimsFromJSON(buf []byte) (IClaims, error) {
+	cl, err := DecodeClaimsFromJSON(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cl.Validate(); err != nil {
+		return nil, err
+	}
+
+	return cl, nil
+}
+
+// DecodeClaimsFromJSON unmarshals CCA platform claims from provided JSON buf.
+func DecodeClaimsFromJSON(buf []byte) (IClaims, error) {
+	cl := NewClaims()
+
+	if err := json.Unmarshal(buf, cl); err != nil {
+		return nil, err
+	}
+
+	return cl, nil
+}
+
+// ValidateAndEncodeClaimsToCBOR validates and then marshals CCA platform claims
+// to CBOR.
+func ValidateAndEncodeClaimsToCBOR(c IClaims) ([]byte, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+
+	return EncodeClaimsToCBOR(c)
+}
+
+// EncodeClaimsToCBOR marshals CCA platform claims to CBOR.
+func EncodeClaimsToCBOR(c IClaims) ([]byte, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	return em.Marshal(c)
+}
+
+// ValidateAndEncodeClaimsToJSON validates and then marshals CCA platform claims
+// to JSON.
+func ValidateAndEncodeClaimsToJSON(c IClaims) ([]byte, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+
+	return EncodeClaimsToJSON(c)
+}
+
+// EncodeClaimsToJSON marshals CCA platform claims to JSON.
+func EncodeClaimsToJSON(c IClaims) ([]byte, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	return json.Marshal(c)
 }

--- a/platform/iclaims_test.go
+++ b/platform/iclaims_test.go
@@ -11,10 +11,10 @@ import (
 
 func Test_DecodeClaims(t *testing.T) {
 	buf := mustHexDecode(t, testEncodedCcaPlatformClaimsAll)
-	_, err := DecodeClaims(buf)
+	_, err := DecodeAndValidateClaimsFromCBOR(buf)
 	assert.NoError(t, err)
 
 	buf = mustHexDecode(t, testEncodedCcaPlatformClaimsInvalidMultiNonce)
-	_, err = DecodeClaims(buf)
-	assert.EqualError(t, err, "validation of CCA platform claims failed: validating nonce: wrong syntax: got 2 nonces, want 1")
+	_, err = DecodeAndValidateClaimsFromCBOR(buf)
+	assert.EqualError(t, err, "validating nonce: wrong syntax: got 2 nonces, want 1")
 }

--- a/realm/claims.go
+++ b/realm/claims.go
@@ -2,7 +2,6 @@
 package realm
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/veraison/eat"
@@ -189,84 +188,4 @@ func (c Claims) GetPubKeyHashAlgID() (string, error) {
 // Semantic validation
 func (c Claims) Validate() error {
 	return ValidateClaims(&c)
-}
-
-// Codecs
-
-func (c *Claims) FromCBOR(buf []byte) error {
-	err := c.FromUnvalidatedCBOR(buf)
-	if err != nil {
-		return err
-	}
-
-	err = c.Validate()
-	if err != nil {
-		return fmt.Errorf("validation of CCA realm claims failed: %w", err)
-	}
-
-	return nil
-}
-
-func (c *Claims) FromUnvalidatedCBOR(buf []byte) error {
-	err := dm.Unmarshal(buf, c)
-	if err != nil {
-		return fmt.Errorf("CBOR decoding of CCA realm claims failed: %w", err)
-	}
-
-	return nil
-}
-
-func (c Claims) ToCBOR() ([]byte, error) {
-	err := c.Validate()
-	if err != nil {
-		return nil, fmt.Errorf("validation of CCA realm claims failed: %w", err)
-	}
-
-	return c.ToUnvalidatedCBOR()
-}
-
-func (c Claims) ToUnvalidatedCBOR() ([]byte, error) {
-	buf, err := em.Marshal(&c)
-	if err != nil {
-		return nil, fmt.Errorf("CBOR encoding of CCA realm claims failed: %w", err)
-	}
-
-	return buf, nil
-}
-
-func (c *Claims) FromJSON(buf []byte) error {
-	if err := c.FromUnvalidatedJSON(buf); err != nil {
-		return err
-	}
-
-	if err := c.Validate(); err != nil {
-		return fmt.Errorf("validation of CCA realm claims failed: %w", err)
-	}
-
-	return nil
-}
-
-func (c *Claims) FromUnvalidatedJSON(buf []byte) error {
-	if err := json.Unmarshal(buf, c); err != nil {
-		return fmt.Errorf("JSON decoding of CCA realm claims failed: %w", err)
-	}
-
-	return nil
-}
-
-func (c Claims) ToJSON() ([]byte, error) {
-	if err := c.Validate(); err != nil {
-		return nil, fmt.Errorf("validation of CCA realm claims failed: %w", err)
-	}
-
-	return c.ToUnvalidatedJSON()
-}
-
-func (c Claims) ToUnvalidatedJSON() ([]byte, error) {
-	buf, err := json.Marshal(&c)
-	if err != nil {
-		return nil, fmt.Errorf("JSON encoding of CCA realm claims failed: %w", err)
-	}
-
-	return buf, nil
 }


### PR DESCRIPTION
This commit refactors marshaling API. It has two objectives:

- Align how marshaling works with conventional Go practices, ensuring new users familiar with other Go libraries have minimal surprises.
- Minimize the impact of marshaling on IClaims interface, relieving the burden on current and future implementations.

To that end, the following changes are made:

- From/To* marshaling API are replaced with implementations of standard cbor and json marshaling interfaces (i.e. Unmasrshal/Marshal*). As per convention, these implementations do not validate.
- There are no validating versions of marshaling methods (thus no requirement for every IClaims implementation to re-implement them). Instead, there are convenience functions that instantiate, marshal, and validate in a single call.
- The functions have been renamed such that Decode* now only performs unmarshaling, and DecodeAndValidate* unmarshals and validates.
- Decoding/Encoding functions for IClaims have been moved from profile.go to iclaims.go.

note: this is implemented on top of [a similar refactor inside psatoken](https://github.com/veraison/psatoken/pull/50/commits/26fe500fd5d4b92d78bcf2fce4070cbbe6d7def7)