### PR TITLE
chore: update go-cose to v1.3.1-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.0.8
 	github.com/stretchr/testify v1.8.1
 	github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53
-	github.com/veraison/go-cose v1.2.1
+	github.com/veraison/go-cose v1.3.0-rc.1
 	github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53 h1:5gnX2TrGd/Xz8DOp2OaLtg/jLoIubSUTrgz6iZ58pJ4=
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
-github.com/veraison/go-cose v1.2.1 h1:Gj4x20D0YP79J2+cK3anjGEMwIkg2xX+TKVVGUXwNAc=
-github.com/veraison/go-cose v1.2.1/go.mod h1:t6V8WJzHm1PD5HNsuDjW3KLv577uWb6UTzbZGvdQHD8=
+github.com/veraison/go-cose v1.3.0-rc.1 h1:j7mMBdwkbq4c+pgEZVbbWG8UwVIgGHPp6+TAAYJj+UY=
+github.com/veraison/go-cose v1.3.0-rc.1/go.mod h1:df09OV91aHoQWLmy1KsDdYiagtXgyAwAl8vFeFn1gMc=
 github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4 h1:N7qg7vDF2mUg7I+8AoU+ieJ20cgcShwFHXHkV5b2YAA=
 github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4/go.mod h1:6+WZzXr0ACXYiUAJJqTaCxW43gY2+gEaCoVNdDv3+Bw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/realm/common.go
+++ b/realm/common.go
@@ -78,15 +78,8 @@ func ValidateRealmPubKeyCOSE(b []byte) error {
 		)
 	}
 
-	if k.KeyType != cose.KeyTypeEC2 {
+	if k.Type != cose.KeyTypeEC2 {
 		return fmt.Errorf("%w: realm public key is not EC2", psatoken.ErrWrongSyntax)
-	}
-
-	if err := k.Validate(); err != nil {
-		return fmt.Errorf(
-			"%w: validating EC2 realm public key: %v",
-			psatoken.ErrWrongSyntax, err,
-		)
 	}
 
 	return nil
@@ -155,12 +148,8 @@ func ECDSAPublicKeyFromCOSEKey(buf []byte) (*ecdsa.PublicKey, error) {
 		return nil, err
 	}
 
-	if k.KeyType != cose.KeyTypeEC2 {
+	if k.Type != cose.KeyTypeEC2 {
 		return nil, errors.New("key type is not EC2")
-	}
-
-	if err := k.Validate(); err != nil {
-		return nil, err
 	}
 
 	pk, err := k.PublicKey()


### PR DESCRIPTION
Explicit calls to `Validate` have been removed because a private `validate` is called implicitly by the relevant methods (at least in the cases we care about here, i.e.: `UnmarshalCBOR` and `PublicKey`.) 