### PR TITLE
fix(realm): enforce exactly 4 realm extended measurements per spec

### DIFF
--- a/realm/claims_test.go
+++ b/realm/claims_test.go
@@ -59,7 +59,17 @@ func Test_CcaRealmClaims_Set_nok(t *testing.T) {
 	assert.EqualError(t, err, expectedErr)
 
 	err = c.SetExtensibleMeasurements([][]byte{})
-	expectedErr = "missing mandatory claim realm extended measurements"
+	expectedErr = "wrong syntax: expected exactly 4 realm extended measurements, got 0"
+	assert.EqualError(t, err, expectedErr)
+
+	meas3 := [][]byte{testInitMeas, testInitMeas, testInitMeas}
+	err = c.SetExtensibleMeasurements(meas3)
+	expectedErr = "wrong syntax: expected exactly 4 realm extended measurements, got 3"
+	assert.EqualError(t, err, expectedErr)
+
+	meas5 := [][]byte{testInitMeas, testInitMeas, testInitMeas, testInitMeas, testInitMeas}
+	err = c.SetExtensibleMeasurements(meas5)
+	expectedErr = "wrong syntax: expected exactly 4 realm extended measurements, got 5"
 	assert.EqualError(t, err, expectedErr)
 
 	err = c.SetHashAlgID("")

--- a/realm/common.go
+++ b/realm/common.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	MaxLenRealmExtendedMeas = 4
+	LenRealmExtendedMeas = 4
 )
 
 // ValidateChallenge returns an error if the provided value does not contain a
@@ -111,12 +111,12 @@ func ValidateHashAlgID(v string) error {
 }
 
 // ValidateExtendedMeas returns an error if the provided slice does not contain
-// valid realm extended measurements (it must be non-empty, and each value must
+// valid realm extended measurements (it must be exactly LenRealmExtendedMeas=4, and each value must
 // be a valid ream measurement).
 func ValidateExtendedMeas(v [][]byte) error {
-	if len(v) == 0 {
-		return fmt.Errorf("%w realm extended measurements",
-			psatoken.ErrMandatoryClaimMissing)
+	if len(v) != LenRealmExtendedMeas {
+		return fmt.Errorf("%w: expected exactly %d realm extended measurements, got %d",
+			psatoken.ErrWrongSyntax, LenRealmExtendedMeas, len(v))
 	}
 
 	for i, meas := range v {


### PR DESCRIPTION
The specification https://www.ietf.org/archive/id/draft-ffm-rats-cca-token-00.html#section-4.8.5 requires exactly 4 realm extensible measurements in the evidence. The previous implementatio only checked for non‑empty values, which allowed invalid inputs. ValidateExtendedMeas now returns ErrWrongSyntax if len(v) != MaxLenRealmExtendedMeas (4).

Fixes: https://github.com/veraison/ccatoken/issues/20